### PR TITLE
Patched GitHub Actions workflow for pull request labeling

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
   final:
-    if: always() && contains(join(needs.*.result, ','), 'success') && github.event == 'pull_request'
+    if: always() && contains(join(needs.*.result, ','), 'success') && github.event_name == 'pull_request'
     needs: [build]
     permissions:
       pull-requests: write
@@ -45,7 +45,7 @@ jobs:
             })
 
   failure:
-    if: failure() && github.event == 'pull_request'
+    if: failure() && github.event_name == 'pull_request'
     needs: [build]
     permissions:
       pull-requests: write

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
   final:
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    if: always() && contains(join(needs.*.result, ','), 'success') && github.event == 'pull_request'
     needs: [build]
     permissions:
       pull-requests: write
@@ -45,7 +45,7 @@ jobs:
             })
 
   failure:
-    if: failure()
+    if: failure() && github.event == 'pull_request'
     needs: [build]
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Changes, summarized

This PR updates the GitHub Actions workflow for the "Build Check" process to include pull request labeling based on the build status. The original workflow was patched to ensure that it doesn't attempt to run the final or failure job on pushes to main, causing the job to fail because you can't label a push to main.

## Changes, bulleted

- Added a condition to the final job to only execute when the triggering event is a pull request.
- Added a condition to the failure job to only execute when the triggering event is a pull request.

## Issue ticket number and link (optional)

N/A
