### PR TITLE
Adding Issue Templates

### DIFF
--- a/.github/issue_template/bug_template.md
+++ b/.github/issue_template/bug_template.md
@@ -1,0 +1,16 @@
+### Description
+
+Generally describe the issue and all aspects of it.
+
+### Expected behavior
+
+What did you expect to happen? Why?
+
+### Reproduction steps
+
+How can someone else reproduce this issue? Detailed.
+
+### Device, OS Version & Browser Version
+
+For example:
+IOS 16.6, iPhone 14, Google Chrome Version 116.0.5845.103

--- a/.github/issue_template/feature_and_refinement_template.md
+++ b/.github/issue_template/feature_and_refinement_template.md
@@ -1,0 +1,7 @@
+### Why
+
+Why should we do this? Explain in detail.
+
+### Proposed Changes:
+
+How would these proposed changes be implemented? What do you propose?


### PR DESCRIPTION
## Changes, summarized

This pull request introduces an `issue_template` folder to the `.github` directory. The folder contains two templates: `bug_template.md` for reporting bugs and `feature_and_refinement_template.md` for suggesting new features or refinements. These templates aim to improve the consistency and quality of issue submissions.

## Changes, bulleted

- Added an `issue_template` folder to the `.github` directory.
- Included `bug_template.md` for reporting bugs.
- Included `feature_and_refinement_template.md` for suggesting new features or refinements.

## Issue ticket number and link (optional)

N/A